### PR TITLE
Forward port to match rdma-core v16.6

### DIFF
--- a/src/ntrdma.h
+++ b/src/ntrdma.h
@@ -49,7 +49,7 @@
 #endif
 
 struct ntrdma_dev {
-	struct ibv_device	ibdev;
+	struct verbs_device	ibdev;
 };
 
 static inline struct ntrdma_dev *to_ntrdma_dev(struct ibv_device *ibdev)


### PR DESCRIPTION
To build use these instructions:
```
[root@host ~]# yum install -y libnl3-devel cmake autoconf automake libtool

[root@host ~]# git clone -b stable-v16 https://github.com/linux-rdma/rdma-core
[root@host ~]# cd /root/rdma-core
[root@host rdma-core]# ./build.sh

[root@host ~]# git clone https://github.com/ntrdma/ntrdma-lib.git
[root@host ~]# cd /root/ntrdma-lib/
[root@host ~]# wget https://github.com/ntrdma/ntrdma-lib/pull/2.patch
[root@host ~]# git apply 2.patch

[root@host ntrdma-lib]# libtoolize
[root@host ntrdma-lib]# aclocal
[root@host ntrdma-lib]# autoconf
[root@host ntrdma-lib]# autoheader
[root@host ntrdma-lib]# automake --add-missing
[root@host ntrdma-lib]# ./configure --libdir=/root/rdma-core/build/lib CFLAGS='-I/root/rdma-core/build/include'
[root@host ntrdma-lib]# make
[root@host ntrdma-lib]# make install

[root@host ntrdma-lib]# ll /usr/lib64/libntrdma*
[root@host ntrdma-lib]# mkdir -p /etc/libibverbs.d
[root@host ntrdma-lib]# cp /var/tmp/libntrdma/ntrdma.driver /etc/libibverbs.d
```